### PR TITLE
Make script compatible with sh

### DIFF
--- a/pp.sh
+++ b/pp.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# this is a POSIX sh compliant version of the script
+
+pp() {
+	# remember output, prevent different clipboard contents
+	# after choosing to execute
+	script=$(xclip -o)
+	echo "$script" | cat -A
+	printf "\nExecute? (y/n): "
+	read execute
+	# only execute when 'y' was answered
+	# all other input is ignored
+	if [ "$execute" = "y" ]; then
+		eval "$script"
+	fi
+}


### PR DESCRIPTION
- function keyword is non-standard
- `` is legacy, $() is preferable
- here-strings are not supported in sh
- echo doesn't support flags in POSIX sh
- [[]] is unsupported in POSIX sh
- $script should be quoted to prevent word-splitting and globbing

If you don't care about sh-compability, which I think is fine, consider PR #2 
