### PR TITLE
Cleanup of pp function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Add the following bash script to your `~/.bashrc`:
 function pp {
 	# remember output, prevent different clipboard contents
 	# after choosing to execute
-	script=`xclip -o`
+	script=$(xclip -o)
 	cat -A <<< $script
 	echo -ne "\nExecute? (y/n): "
 	read execute
 	# only execute when 'y' was answered
 	# all other input is ignored
 	if [[ $execute == "y" ]]; then
-		eval $script
+		eval "$script"
 	fi
 }
 ```


### PR DESCRIPTION
- Use $() instead of ``
- Double-quote $script to prevent globbing and word-splitting

If you don't care about compability with POSIX sh then this PR is preferable to #1 
